### PR TITLE
Improve texts and flow in GodkjennPlan

### DIFF
--- a/js/components/oppfolgingsdialog/OppfolgingsdialogerInfoPersonvern.js
+++ b/js/components/oppfolgingsdialog/OppfolgingsdialogerInfoPersonvern.js
@@ -5,6 +5,7 @@ const texts = {
         Oppfølgingsplanen skal gjøre det lettere for arbeidstakeren å bli i jobben.
         Du og arbeidstakeren lager planen sammen og skriver inn opplysninger fra hver deres kant.
         Formålet er finne ut hvilke oppgaver som kan gjøres hvis det legges til rette. Dere kan endre planen når som helst etter hvert som dere ser hvordan det går.
+        Alle godkjente planer mellom deg og arbeidstakeren vil også bli tilgjengelige for de hos dere som har tilganger i Altinn.
     `,
     readMore: {
         title: 'Les mer om:',

--- a/js/components/oppfolgingsdialog/godkjennplan/Godkjenn.js
+++ b/js/components/oppfolgingsdialog/godkjennplan/Godkjenn.js
@@ -50,31 +50,28 @@ class Godkjenn extends Component {
             settAktivtSteg,
             rootUrl,
         } = this.props;
-        return (<div ref={this.formRef}>
-            {
-                (() => {
-                    if (this.state.visGodkjenPlanSkjema) {
-                        return (<GodkjennPlanLightboks
-                            avbryt={this.lukkGodkjenPlanSkjema}
-                            rootUrl={rootUrl}
-                            oppfolgingsdialog={oppfolgingsdialog}
-                            godkjennPlan={this.sendGodkjennPlan}
-                        />);
-                    }
-                    return (<div className="godkjennPlanOversikt">
-                        <GodkjennPlanOversiktInformasjon
-                            oppfolgingsdialog={oppfolgingsdialog}
-                            rootUrl={rootUrl}
-                        />
+        return (<div ref={this.formRef} className="godkjennPlanOversikt">
+            <GodkjennPlanOversiktInformasjon
+                oppfolgingsdialog={oppfolgingsdialog}
+                rootUrl={rootUrl}
+            />
 
-                        <ReviderEllerGodkjennPlan
-                            oppfolgingsdialog={oppfolgingsdialog}
-                            rootUrl={rootUrl}
-                            settAktivtSteg={settAktivtSteg}
-                            visSendTilGodkjenning={this.visGodkjenPlanSkjema}
-                        />
-                    </div>);
-                })()
+            {!this.state.visGodkjenPlanSkjema &&
+            <ReviderEllerGodkjennPlan
+                oppfolgingsdialog={oppfolgingsdialog}
+                rootUrl={rootUrl}
+                settAktivtSteg={settAktivtSteg}
+                visSendTilGodkjenning={this.visGodkjenPlanSkjema}
+            />
+            }
+
+            {this.state.visGodkjenPlanSkjema &&
+            <GodkjennPlanLightboks
+                avbryt={this.lukkGodkjenPlanSkjema}
+                rootUrl={rootUrl}
+                oppfolgingsdialog={oppfolgingsdialog}
+                godkjennPlan={this.sendGodkjennPlan}
+            />
             }
         </div>);
     }

--- a/js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanLightboks.js
+++ b/js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanLightboks.js
@@ -15,19 +15,20 @@ import GodkjennPlanSkjemaDatovelger from './GodkjennPlanSkjemaDatovelger';
 import { oppfolgingsdialogPt } from '../../../proptypes/opproptypes';
 
 const texts = {
-    title: 'Du sender nå en oppfølgingsplan til arbeidstakeren for godkjenning',
-    info: `
-        Arbeidstakeren kan deretter gjøre endringer i oppfølgingsplanen. Da får du den til ny godkjenning.
-        Alle godkjente planer mellom deg og arbeidstakeren vil også bli tilgjengelige for de hos dere som har tilganger i Altinn.
-    `,
+    title: 'Vurder ferdigstilling av plan',
+    info: 'Arbeidstakeren kan deretter enten godkjenne eller gjøre endringer i oppfølgingsplanen og sende planen tilbake til deg for ny godkjenning.',
     titleDatovelger: 'Når skal planen vare fra og til?',
     checkboxLabel: 'Jeg er enig i denne oppfølgingsplanen',
     approval: {
+        question: 'Ønsker du godkjenning av arbeidstaker eller å opprette plan på vegne av arbeidstakeren?',
         sendForApproval: 'Send planen til arbeidstakeren for godkjenning',
-        sendWithoutApproval: 'Opprett en utgave uten godkjenning fra arbeidstakeren',
+        sendWithoutApproval: 'Opprett planen på vegne av arbeidstakeren',
     },
     infoWithoutApproval: 'En plan uten godkjenning fra den sykmeldte skal kun opprettes dersom den sykmeldte ikke kan eller ønsker å delta. Dette vil bli synlig i planen.',
-    buttonSend: 'Send til godkjenning',
+    buttonSend: {
+        approval: 'Send til godkjenning',
+        noApproval: 'Opprett plan',
+    },
     buttonCancel: 'Avbryt',
 };
 
@@ -39,8 +40,10 @@ export class GodkjennPlanLightboksComponent extends Component {
     constructor(props) {
         super(props);
         this.state = {
+            radioSelected: false,
+            createWithoutApproval: false,
             visIkkeUtfyltFeilmelding: false,
-            opprettplan: 'true',
+            opprettplan: '',
         };
         this.godkjennPlan = this.godkjennPlan.bind(this);
         this.handledChange = this.handledChange.bind(this);
@@ -60,7 +63,6 @@ export class GodkjennPlanLightboksComponent extends Component {
         initData.startdato = window.sessionStorage.getItem('startdato');
         initData.sluttdato = window.sessionStorage.getItem('sluttdato');
         initData.evalueringsdato = window.sessionStorage.getItem('evalueringsdato');
-        initData.opprettplan = true;
         initData.delMedNav = false;
         this.props.initialize(initData);
     }
@@ -82,7 +84,10 @@ export class GodkjennPlanLightboksComponent extends Component {
     }
 
     handledChange(e) {
+        const createWithoutApproval = e.target.value !== 'true';
         this.setState({
+            radioSelected: true,
+            createWithoutApproval,
             opprettplan: e.target.value,
             visIkkeUtfyltFeilmelding: false,
         });
@@ -97,6 +102,8 @@ export class GodkjennPlanLightboksComponent extends Component {
         return (<div ref={this.formRef} className="panel godkjennPlanLightboks">
             <form onSubmit={handleSubmit(this.godkjennPlan)} className="godkjennPlanSkjema">
                 <h2>{texts.title}</h2>
+
+                <h3>{texts.approval.question}</h3>
 
                 <div className="inputgruppe">
                     <Field
@@ -131,41 +138,60 @@ export class GodkjennPlanLightboksComponent extends Component {
                 </Alertstripe>
                 }
 
-                <p>{texts.info}</p>
+                { this.state.opprettplan === 'true' &&
+                <Alertstripe
+                    className="alertstripe--notifikasjonboks"
+                    type="info"
+                    solid>
+                    {texts.info}
+                </Alertstripe>
+                }
 
-                <hr />
+                { this.state.radioSelected &&
+                <React.Fragment>
+                    <hr />
 
-                <h3>{texts.titleDatovelger}</h3>
+                    <h3>{texts.titleDatovelger}</h3>
 
-                <GodkjennPlanSkjemaDatovelger />
+                    <GodkjennPlanSkjemaDatovelger />
+                </React.Fragment>
+                }
 
-                <hr />
+                { this.state.radioSelected &&
+                <React.Fragment>
+                    <hr />
 
-                <div className="inputgruppe">
-                    <div className="skjema__input">
-                        <Field
-                            className="checkboks"
-                            id="godkjennInput"
-                            name="godkjennInput"
-                            component={CheckboxSelvstendig}
-                            label={texts.checkboxLabel}
-                        />
-                        <Field
-                            className="checkboks"
-                            id="delMedNav"
-                            name="delMedNav"
-                            component={CheckboxSelvstendig}
-                            label={textDelMedNav(oppfolgingsdialog.arbeidstaker.navn)}
-                        />
+                    <div className="inputgruppe">
+                        <div className="skjema__input">
+                            <Field
+                                className="checkboks"
+                                id="godkjennInput"
+                                name="godkjennInput"
+                                component={CheckboxSelvstendig}
+                                label={texts.checkboxLabel}
+                            />
+                            <Field
+                                className="checkboks"
+                                id="delMedNav"
+                                name="delMedNav"
+                                component={CheckboxSelvstendig}
+                                label={textDelMedNav(oppfolgingsdialog.arbeidstaker.navn)}
+                            />
+                        </div>
                     </div>
-                </div>
-
+                </React.Fragment>
+                }
                 <div className="knapperad">
                     <div className="knapperad__element">
+                        { this.state.radioSelected &&
                         <Hovedknapp
                             htmlType="submit">
-                            {texts.buttonSend}
+                            {this.state.createWithoutApproval
+                                ? texts.buttonSend.noApproval
+                                : texts.buttonSend.approval
+                            }
                         </Hovedknapp>
+                        }
                     </div>
                     <div className="knapperad__element">
                         <button

--- a/js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanVenterInfo.js
+++ b/js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanVenterInfo.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const texts = {
+    infolist: {
+        ingress: 'Arbeidstakeren kan enten godkjenne eller gjøre endringer i oppfølgingsplanen:',
+        noChangesApproval: 'Godkjenner arbeidstakeren vil du motta et varsel om at har dere opprettet en gjeldende plan.',
+        changesWithAproval: 'Gjør arbeidstakeren endringer og sender den tilbake til deg for godkjenning, vil du motta et varsel om å ta stilling dette.',
+        changesNoApproval: `
+            Mottar du ikke varsel knyttet til planen har ikke arbeidstakeren din tatt stilling til den. 
+            For å komme videre kan du ta kontakt med arbeidstakeren eller gå inn på denne oppfølgingsplanen og se om det er gjort endringer. 
+        `,
+        afterApproval: `
+            Om arbeidstakeren godkjenner planen, har dere opprettet en gjeldende plan som du kan laste ned.
+            Planen er tilgjengelig her i fire måneder etter friskmelding.
+        `,
+    },
+};
+
+
+const GodkjennPlanVenterInfo = () => {
+    return (
+        <React.Fragment>
+            <p>{texts.infolist.ingress}</p>
+            <ul>
+                <li>{texts.infolist.noChangesApproval}</li>
+                <li>{texts.infolist.changesWithAproval}</li>
+                <li>{texts.infolist.changesNoApproval}</li>
+            </ul>
+            <p>{texts.infolist.afterApproval}</p>
+        </React.Fragment>);
+};
+
+export default GodkjennPlanVenterInfo;

--- a/js/components/oppfolgingsdialog/godkjennplan/godkjenninger/GodkjennPlanSendt.js
+++ b/js/components/oppfolgingsdialog/godkjennplan/godkjenninger/GodkjennPlanSendt.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { Utvidbar } from '@navikt/digisyfo-npm';
 import { oppfolgingsdialogPt } from '../../../../proptypes/opproptypes';
 import { finnNyesteGodkjenning } from '../../../../utils/oppfolgingsplanUtils';
@@ -7,14 +8,11 @@ import GodkjennPlanOversiktInformasjon from '../GodkjennPlanOversiktInformasjon'
 import OppfolgingsplanInnholdboks from '../../../app/OppfolgingsplanInnholdboks';
 import GodkjennPlanTidspunkt from '../GodkjennPlanTidspunkt';
 import TidligereAvbruttePlaner from '../TidligereAvbruttePlaner';
+import GodkjennPlanVenterInfo from '../GodkjennPlanVenterInfo';
 
 const texts = {
     godkjennPlanSendtInfoTekst: {
         title: 'Hva skjer nå?',
-        paragraph: `
-            Du har lagret en versjon av oppfølgingsplanen.
-            Når den ansatte har godkjent planen, kan du laste den ned. Planen er tilgjengelig her i fire måneder etter friskmelding.
-        `,
     },
     godkjennPlanSendtUtvidbar: {
         title: 'Se planen',
@@ -25,11 +23,34 @@ const texts = {
     },
 };
 
+const CancelButtonStyled = styled.button`
+    margin-top: 1em;
+`;
+export const CancelButton = (
+    {
+        nullstillGodkjenning,
+        oppfolgingsplan,
+    }) => {
+    return (
+        <CancelButtonStyled
+            className="lenke"
+            onClick={() => {
+                nullstillGodkjenning(oppfolgingsplan.id, oppfolgingsplan.arbeidstaker.fnr);
+            }}>
+            {texts.godkjennPlanSendt.buttonUndo}
+        </CancelButtonStyled>
+    );
+};
+CancelButton.propTypes = {
+    nullstillGodkjenning: PropTypes.func,
+    oppfolgingsplan: oppfolgingsdialogPt,
+};
+
 export const GodkjennPlanSendtInfoTekst = () => {
     return (
         <div className="godkjennPlanSendt_infoTekst">
             <h3 className="typo-element">{texts.godkjennPlanSendtInfoTekst.title}</h3>
-            <p>{texts.godkjennPlanSendtInfoTekst.paragraph}</p>
+            <GodkjennPlanVenterInfo />
         </div>
     );
 };
@@ -80,6 +101,10 @@ const GodkjennPlanSendt = ({ oppfolgingsdialog, nullstillGodkjenning, rootUrl, r
                     oppfolgingsdialog={oppfolgingsdialog}
                     rootUrl={rootUrl}
                 />
+                <CancelButton
+                    nullstillGodkjenning={nullstillGodkjenning}
+                    oppfolgingsplan={oppfolgingsdialog}
+                />
                 <TidligereAvbruttePlaner
                     oppfolgingsdialog={oppfolgingsdialog}
                     rootUrlPlaner={rootUrlPlaner}
@@ -87,13 +112,6 @@ const GodkjennPlanSendt = ({ oppfolgingsdialog, nullstillGodkjenning, rootUrl, r
                 <GodkjennPlanSendtInfoTekst
                     oppfolgingsdialog={oppfolgingsdialog}
                 />
-                <button
-                    className="lenke"
-                    onClick={() => {
-                        nullstillGodkjenning(oppfolgingsdialog.id, oppfolgingsdialog.arbeidstaker.fnr);
-                    }}>
-                    {texts.godkjennPlanSendt.buttonUndo}
-                </button>
             </div>
         </OppfolgingsplanInnholdboks>
     );

--- a/styles/_godkjennPlanSkjema.less
+++ b/styles/_godkjennPlanSkjema.less
@@ -5,8 +5,7 @@
 }
 .godkjennPlanSkjema__datovelger__rad {
     width: 100%;
-    margin-bottom: 2em;
-    margin-top: 2em;
+    margin: 1em 0;
     @media all and (max-width: @screen-xs-max) {
         margin-bottom: 0;
     }

--- a/test/components/oppfolgingsdialog/godkjennplan/GodkjennPlanLightboksTest.js
+++ b/test/components/oppfolgingsdialog/godkjennplan/GodkjennPlanLightboksTest.js
@@ -40,10 +40,18 @@ describe('GodkjennPlanLightboks', () => {
     it('Skal vise overskrifter og tekster', () => {
         expect(komponent.find('h2')).to.have.length(1);
         expect(komponent.find('h3')).to.have.length(1);
-        expect(komponent.find('p')).to.have.length(1);
     });
 
-    it('Skal vise GodkjennPlanSkjemaDatovelger', () => {
+    it('Skal ikke vise Alertstripe, GodkjennPlanSkjemaDatovelger eller Hovedknapp i startilstand(radioSelected er true)', () => {
+        expect(komponent.find(Alertstripe)).to.have.length(0);
+        expect(komponent.find(GodkjennPlanSkjemaDatovelger)).to.have.length(0);
+        expect(komponent.find(Hovedknapp)).to.have.length(0);
+    });
+
+    it('Skal vise GodkjennPlanSkjemaDatovelger om radioSelected er true', () => {
+        komponent.setState({
+            radioSelected: true,
+        });
         expect(komponent.find(GodkjennPlanSkjemaDatovelger)).to.have.length(1);
     });
 
@@ -61,7 +69,24 @@ describe('GodkjennPlanLightboks', () => {
         expect(komponent.find(Alertstripe)).to.have.length(0);
     });
 
-    it('Skal vise en submit knapp', () => {
+    it('Skal vise Alertstripe, om tvungenGodkjenning er valgt', () => {
+        komponent.setState({
+            opprettplan: 'true',
+        });
+        expect(komponent.find(Alertstripe)).to.have.length(1);
+    });
+
+    it('Skal vise Alertstripe, om radioSelected er true', () => {
+        komponent.setState({
+            opprettplan: 'true',
+        });
+        expect(komponent.find(Alertstripe)).to.have.length(1);
+    });
+
+    it('Skal vise en submit knapp om radioSelected er true', () => {
+        komponent.setState({
+            radioSelected: true,
+        });
         expect(komponent.find(Hovedknapp)).to.have.length(1);
     });
 

--- a/test/components/oppfolgingsdialog/godkjennplan/godkjenninger/GodkjennPlanSendtTest.js
+++ b/test/components/oppfolgingsdialog/godkjennplan/godkjenninger/GodkjennPlanSendtTest.js
@@ -4,10 +4,12 @@ import { shallow } from 'enzyme';
 import chaiEnzyme from 'chai-enzyme';
 import { Utvidbar } from '@navikt/digisyfo-npm';
 import GodkjennPlanSendt, {
+    CancelButton,
     GodkjennPlanSendtInfoTekst,
     GodkjennPlanSendtUtvidbar,
 } from '../../../../../js/components/oppfolgingsdialog/godkjennplan/godkjenninger/GodkjennPlanSendt';
 import GodkjennPlanOversiktInformasjon from '../../../../../js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanOversiktInformasjon';
+import GodkjennPlanVenterInfo from '../../../../../js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanVenterInfo';
 import OppfolgingsplanInnholdboks from '../../../../../js/components/app/OppfolgingsplanInnholdboks';
 import getOppfolgingsdialog from '../../../../mock/mockOppfolgingsdialog';
 
@@ -44,8 +46,8 @@ describe('GodkjennPlanSendt', () => {
         expect(komponentDefault.find(GodkjennPlanSendtUtvidbar)).to.have.length(1);
     });
 
-    it('Skal vise en knapp for aa trekke tilbake sendt godkjenning', () => {
-        expect(komponentDefault.find('button.lenke')).to.have.length(1);
+    it('Skal vise CancelButton', () => {
+        expect(komponentDefault.find(CancelButton)).to.have.length(1);
     });
 
     describe('GodkjennPlanSendtUtvidbar', () => {
@@ -63,7 +65,10 @@ describe('GodkjennPlanSendt', () => {
         it('Skal vise en GodkjennPlanSendtInfoTekst med overskrift og tekst', () => {
             expect(komponent.find('div.godkjennPlanSendt_infoTekst')).to.have.length(1);
             expect(komponent.find('h3')).to.have.length(1);
-            expect(komponent.find('p')).to.have.length(1);
+        });
+
+        it('Skal vise GodkjennPlanVenterInfo', () => {
+            expect(komponent.find(GodkjennPlanVenterInfo)).to.have.length(1);
         });
     });
 });


### PR DESCRIPTION
Endrer tekster og flyt ved sending av plan til arbeidstaker for godkjenning:
- Flytter visning for sending av plan til godkjenning fra egen visning til visning under oversikt over plan.
- Arbeidsgiver må nå først svare på om det er ønskelig å sende til godkjenning eller opprette plan uten godkjenning før man får velge periode og sende plan.
- Mer utfyllende tekst i "Hva skjer nå" i visning etter at arbeidsgiver har sendt plan til godkjenning.