### PR TITLE
Make contactinfo collapsable in view of Plan

### DIFF
--- a/js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanOversiktInformasjon.js
+++ b/js/components/oppfolgingsdialog/godkjennplan/GodkjennPlanOversiktInformasjon.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { HjelpetekstUnderVenstre } from 'nav-frontend-hjelpetekst';
-import { toDatePrettyPrint } from '@navikt/digisyfo-npm';
+import {
+    toDatePrettyPrint,
+    Utvidbar,
+} from '@navikt/digisyfo-npm';
 import { KANGJENNOMFOERES, STATUS_TILTAK } from '../../../konstanter';
 import { toDateMedMaanedNavn } from '../../../utils/datoUtils';
 import { capitalizeFirstLetter } from '../../../utils/tekstUtils';
@@ -106,11 +109,7 @@ InformasjonPanelOverskrift.propTypes = {
 
 export const InformasjonPanelArbeidsgiver = ({ naermesteLeder, virksomhetsnummer }) => {
     return (
-        <div className="panel godkjennPlanOversiktInformasjon__panel">
-            <div className="godkjennPlanOversiktInformasjon__panel__header">
-                <h3>{texts.informasjonPanelArbeidsgiver.title}</h3>
-            </div>
-
+        <Utvidbar className="informasjonPanelUtvidbar" tittel={texts.informasjonPanelArbeidsgiver.title}>
             <dl className="godkjennPlanOversiktInformasjon__panel__info">
                 <dt>{texts.informasjonPanelArbeidsgiver.labels.virksomhetsnummer}</dt>
                 <dd>{virksomhetsnummer}</dd>
@@ -132,7 +131,7 @@ export const InformasjonPanelArbeidsgiver = ({ naermesteLeder, virksomhetsnummer
                     </div>,
                 ]}
             </dl>
-        </div>
+        </Utvidbar>
     );
 };
 InformasjonPanelArbeidsgiver.propTypes = {
@@ -150,10 +149,7 @@ RenderStilling.propTypes = {
 
 export const InformasjonPanelSykmeldt = ({ arbeidstaker }) => {
     return (
-        <div className="panel godkjennPlanOversiktInformasjon__panel">
-            <div className="godkjennPlanOversiktInformasjon__panel__header">
-                <h3>{texts.informasjonPanelSykmeldt.title}</h3>
-            </div>
+        <Utvidbar className="informasjonPanelUtvidbar" tittel={texts.informasjonPanelSykmeldt.title}>
             <dl className="godkjennPlanOversiktInformasjon__panel__info">
                 <dt>{texts.informasjonPanelSykmeldt.labels.fnr}</dt>
                 <dd>{arbeidstaker.fnr}</dd>
@@ -184,7 +180,7 @@ export const InformasjonPanelSykmeldt = ({ arbeidstaker }) => {
                 </div>
                 }
             </dl>
-        </div>
+        </Utvidbar>
     );
 };
 InformasjonPanelSykmeldt.propTypes = {

--- a/styles/_godkjennPlanOversiktInformasjon.less
+++ b/styles/_godkjennPlanOversiktInformasjon.less
@@ -7,6 +7,28 @@
     }
 }
 
+.informasjonPanelUtvidbar {
+    border: 0 !important;
+    border-bottom: 0.1em solid #efefef !important;
+
+    h3 {
+        margin: 0;
+    }
+
+    .utvidbar__header {
+        padding-left: 1em;
+        padding-right: 1em;
+        @media (min-width: @screen-sm-min) {
+            padding-left: 2em;
+            padding-right: 2em;
+        }
+    }
+
+    .utvidbar__tittel {
+        .typo-undertittel-mixin();
+    }
+}
+
 .godkjennPlanOversiktInformasjon__panel {
     margin-bottom: 0 !important;
     border-bottom: 0.1em solid #efefef;

--- a/test/components/oppfolgingsdialog/godkjennplan/GodkjennPlanOversiktInformasjonTest.js
+++ b/test/components/oppfolgingsdialog/godkjennplan/GodkjennPlanOversiktInformasjonTest.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import React from 'react';
 import { shallow } from 'enzyme';
 import chaiEnzyme from 'chai-enzyme';
+import { Utvidbar } from '@navikt/digisyfo-npm';
 import GodkjennPlanOversiktInformasjon, {
     InformasjonPanelOverskrift,
     InformasjonPanelSykmeldt,
@@ -99,12 +100,8 @@ describe('GodkjennPlanOversiktInformasjon', () => {
             virksomhetsnummer={oppfolgingsdialog.virksomhetsnummer}
         />);
 
-        it('Skal vise en InformasjonPanelOverskrift', () => {
-            expect(komponent.find('div.godkjennPlanOversiktInformasjon__panel')).to.have.length(1);
-        });
-
-        it('Skal vise en Overskrift', () => {
-            expect(komponent.find('div.godkjennPlanOversiktInformasjon__panel__header')).to.have.length(1);
+        it('Skal vise Utvidbar', () => {
+            expect(komponent.find(Utvidbar)).to.have.length(1);
         });
 
         it('Skal vise Felter med informasjon', () => {
@@ -119,12 +116,8 @@ describe('GodkjennPlanOversiktInformasjon', () => {
             naermesteLeder={oppfolgingsdialog.arbeidsgiver.naermesteLeder}
         />);
 
-        it('Skal vise en InformasjonPanelOverskrift', () => {
-            expect(komponent.find('div.godkjennPlanOversiktInformasjon__panel')).to.have.length(1);
-        });
-
-        it('Skal vise en Overskrift', () => {
-            expect(komponent.find('div.godkjennPlanOversiktInformasjon__panel__header')).to.have.length(1);
+        it('Skal vise Utvidbar', () => {
+            expect(komponent.find(Utvidbar)).to.have.length(1);
         });
 
         it('Skal vise Felter med informasjon', () => {


### PR DESCRIPTION
- Gjør om panel med kontaktinfo for sykmeldt/arbeidsgiver til en Utvidbar som er lukket i starttilstand. Dette gjøres for å gi mindre scrollin og bedre oversikt over den mest relevante informasjonen for bruker.