### PR TITLE
Fix filter methods in kontaktinfo reducer

### DIFF
--- a/js/reducers/kontaktinfo.js
+++ b/js/reducers/kontaktinfo.js
@@ -13,27 +13,27 @@ const kontaktinfo = (state = initiellState, action = {}) => {
         case actions.HENTER_KONTAKTINFO: {
             return Object.assign({}, state, {
                 henter: state.henter.concat(action.fnr),
-                hentingFeilet: state.hentingFeilet.filter((hentingFeilet) => {
-                    return hentingFeilet.fnr !== action.fnr;
+                hentingFeilet: state.hentingFeilet.filter((fnr) => {
+                    return fnr !== action.fnr;
                 }),
             });
         }
         case actions.KONTAKTINFO_HENTET: {
             return Object.assign({}, state, {
-                henter: state.henter.filter((henter) => {
-                    return henter !== action.fnr;
+                henter: state.henter.filter((fnr) => {
+                    return fnr !== action.fnr;
                 }),
                 data: state.data.concat({ fnr: action.fnr, kontaktinfo: action.kontaktinfo }),
                 hentet: state.hentet.concat(action.fnr),
-                hentingFeilet: state.hentingFeilet.filter((hentingFeilet) => {
-                    return hentingFeilet.fnr !== action.fnr;
+                hentingFeilet: state.hentingFeilet.filter((fnr) => {
+                    return fnr !== action.fnr;
                 }),
             });
         }
         case actions.HENT_KONTAKTINFO_FEILET: {
             return Object.assign({}, state, {
-                henter: state.henter.filter((henter) => {
-                    return henter.fnr !== action.fnr;
+                henter: state.henter.filter((fnr) => {
+                    return fnr !== action.fnr;
                 }),
                 hentingFeilet: state.hentingFeilet.concat(action.fnr),
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -826,7 +826,7 @@
     },
     "array-differ": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
@@ -849,7 +849,7 @@
     },
     "array-from": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
@@ -1068,7 +1068,7 @@
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
@@ -2505,7 +2505,7 @@
     },
     "beeper": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
@@ -2914,7 +2914,7 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
@@ -3011,7 +3011,7 @@
     },
     "classnames": {
       "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/classnames/-/classnames-2.2.5.tgz",
       "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
     },
     "cli-cursor": {
@@ -3059,13 +3059,13 @@
     },
     "clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-stats": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
@@ -3289,7 +3289,7 @@
     },
     "cosmiconfig": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "dev": true,
       "requires": {
@@ -3304,7 +3304,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -3562,7 +3562,7 @@
     },
     "dateformat": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/dateformat/-/dateformat-2.2.0.tgz",
       "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true
     },
@@ -3591,7 +3591,7 @@
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
@@ -3878,7 +3878,7 @@
     },
     "duplexer2": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
@@ -3887,13 +3887,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3905,7 +3905,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -4829,7 +4829,7 @@
     },
     "extract-text-webpack-plugin": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz",
       "integrity": "sha1-aTFbiF+Hbb+W04Gfap8cynrr8Vk=",
       "dev": true,
       "requires": {
@@ -4841,7 +4841,7 @@
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
@@ -5865,7 +5865,7 @@
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
@@ -5979,7 +5979,7 @@
     },
     "gulp-util": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
@@ -6005,13 +6005,13 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "object-assign": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
           "dev": true
         }
@@ -6019,7 +6019,7 @@
     },
     "gulplog": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
@@ -6046,7 +6046,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -6091,7 +6091,7 @@
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
@@ -7262,7 +7262,7 @@
       "dependencies": {
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/esprima/-/esprima-4.0.1.tgz",
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         }
@@ -7329,7 +7329,7 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
@@ -7578,55 +7578,55 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basetostring": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
       "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
       "dev": true
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
       "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
       "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
       "dev": true
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
       "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash._root": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash._root/-/lodash._root-3.0.1.tgz",
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
@@ -7650,7 +7650,7 @@
     },
     "lodash.escape": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
@@ -7665,13 +7665,13 @@
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
@@ -7689,7 +7689,7 @@
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -7700,7 +7700,7 @@
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
@@ -7712,7 +7712,7 @@
     },
     "lodash.template": {
       "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
@@ -7729,7 +7729,7 @@
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
@@ -7739,7 +7739,7 @@
     },
     "lodash.throttle": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "log-symbols": {
@@ -8088,7 +8088,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
@@ -8387,7 +8387,7 @@
       "dependencies": {
         "glob": {
           "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
@@ -8418,7 +8418,7 @@
     },
     "multipipe": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
       "dev": true,
       "requires": {
@@ -8501,12 +8501,12 @@
     },
     "nav-frontend-alertstriper": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/nav-frontend-alertstriper/-/nav-frontend-alertstriper-1.0.14.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-alertstriper/-/nav-frontend-alertstriper-1.0.14.tgz",
       "integrity": "sha512-sf1yqX9KqCKmOa4IiSxb9LoJz+zO3l2on6GH3nOXtVhq1cWVowCgUOhdy6MmI3ooODv5MuttYAkS15Kdugu8QA=="
     },
     "nav-frontend-alertstriper-style": {
       "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/nav-frontend-alertstriper-style/-/nav-frontend-alertstriper-style-0.2.35.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-alertstriper-style/-/nav-frontend-alertstriper-style-0.2.35.tgz",
       "integrity": "sha512-fdcaKpVme5nNvkYNy34u7jUxorRlw8ljzPk+d+Sk487sj+F/wHkRbfWecoAmkU4IRYGMBdLHdx7x5fN7CfU1pg=="
     },
     "nav-frontend-chevron": {
@@ -8526,27 +8526,27 @@
     },
     "nav-frontend-etiketter": {
       "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/nav-frontend-etiketter/-/nav-frontend-etiketter-0.2.15.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-etiketter/-/nav-frontend-etiketter-0.2.15.tgz",
       "integrity": "sha512-/UoZzX3Gmp8EtZ9mVgGja+JnuMbrOYspci0yl4ewOj0/oxN0ib5g63fa+q0uUgCpGx9WKs5cMDczjJfvT2Papg=="
     },
     "nav-frontend-etiketter-style": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/nav-frontend-etiketter-style/-/nav-frontend-etiketter-style-0.3.4.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-etiketter-style/-/nav-frontend-etiketter-style-0.3.4.tgz",
       "integrity": "sha512-AgPHBG0qAMPyWh4XByM9s1q1ddS0SCb8fMWluIJSrW2oIk48Z/p3yGpYfQLR+xq2d9+xK7qtprUoiiBBEx9baA=="
     },
     "nav-frontend-hjelpetekst": {
       "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/nav-frontend-hjelpetekst/-/nav-frontend-hjelpetekst-1.0.15.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-hjelpetekst/-/nav-frontend-hjelpetekst-1.0.15.tgz",
       "integrity": "sha512-tPXLoY9Ca/uQrLHBRnml1xRCw+yTUdiXPn6CS44RzoRHSgi1tSJ8Y3xgIi+mL8pkg8Kia6jgSDNwwu7i8YwFlw=="
     },
     "nav-frontend-hjelpetekst-style": {
       "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/nav-frontend-hjelpetekst-style/-/nav-frontend-hjelpetekst-style-0.3.14.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-hjelpetekst-style/-/nav-frontend-hjelpetekst-style-0.3.14.tgz",
       "integrity": "sha512-mxrbExslakCt9s8l6SRnt8UaxqcAQjhRu5vpfI5YNjW3r3VegmP0q3qRXgmtVqSVAzlpcQ2aC18KE+KaprHJNA=="
     },
     "nav-frontend-ikoner-assets": {
       "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/nav-frontend-ikoner-assets/-/nav-frontend-ikoner-assets-0.2.27.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-ikoner-assets/-/nav-frontend-ikoner-assets-0.2.27.tgz",
       "integrity": "sha512-htUaAOB5M48Ajv6noPEH1v8qgypjPW1RWp8RiE8Px/SCwEPZlYsabTvZrA2VLvILQTVk3Hf1feKOH/k1Oihfgw=="
     },
     "nav-frontend-js-utils": {
@@ -8556,12 +8556,12 @@
     },
     "nav-frontend-knapper": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nav-frontend-knapper/-/nav-frontend-knapper-1.0.10.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-knapper/-/nav-frontend-knapper-1.0.10.tgz",
       "integrity": "sha512-Y7Fr8IjS87W4VAyx4OKNb7f7UA34BTzUwF83fCQZn9/9vad0UIGUxRdls6i33DPzhbimvw/vHdKXU0DNtHw+Pg=="
     },
     "nav-frontend-knapper-style": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/nav-frontend-knapper-style/-/nav-frontend-knapper-style-0.3.9.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-knapper-style/-/nav-frontend-knapper-style-0.3.9.tgz",
       "integrity": "sha512-uiC71zFCRP7Ag/vI8slMfkMGGu5Tces9CZsEHpowoWfugiHOhX8pijNW16kryh1fF2ty/t/+8jjDF5lnOJoN+A=="
     },
     "nav-frontend-lenker-style": {
@@ -8571,27 +8571,27 @@
     },
     "nav-frontend-lukknapp": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/nav-frontend-lukknapp/-/nav-frontend-lukknapp-1.0.6.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-lukknapp/-/nav-frontend-lukknapp-1.0.6.tgz",
       "integrity": "sha512-4jAine3zV2vvhPfPOoET6mzIVdPe9W0iYxvdFKS8HJmD51Gg+u8KoUrEMoGWJvoSSX3j19eYNi7F6QtUMSLmDw=="
     },
     "nav-frontend-lukknapp-style": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/nav-frontend-lukknapp-style/-/nav-frontend-lukknapp-style-0.2.7.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-lukknapp-style/-/nav-frontend-lukknapp-style-0.2.7.tgz",
       "integrity": "sha512-Yw4VST5YfjckyUWZDkf2cg/dwUJXadd/r9pmhl7qntHMvZAdgp8rZKnlwHekW6A+COQlEc7JmbmAITc8oy33FA=="
     },
     "nav-frontend-modal": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/nav-frontend-modal/-/nav-frontend-modal-1.0.7.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-modal/-/nav-frontend-modal-1.0.7.tgz",
       "integrity": "sha512-CgWtkzUOwhd8Mh0sF65+fqgn7Uy1VgeC1VsDJ0Tk+MoK3b5rx9LmKaCOEBwPGWy0ZjbZ2x8fQCoiE8l60Y/z1w=="
     },
     "nav-frontend-modal-style": {
       "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/nav-frontend-modal-style/-/nav-frontend-modal-style-0.3.12.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-modal-style/-/nav-frontend-modal-style-0.3.12.tgz",
       "integrity": "sha512-KHVLbT8VdrENnay6dxQgDBa8Yir4b4lvC/ChADxyrf0HpR2RWPGKDsa4zA4Y8rhrv/zv91x4TDMFVBS4HXgrJg=="
     },
     "nav-frontend-paneler-style": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/nav-frontend-paneler-style/-/nav-frontend-paneler-style-0.3.9.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-paneler-style/-/nav-frontend-paneler-style-0.3.9.tgz",
       "integrity": "sha512-uAIZigNa5Nto8goesnk+N8V6MtC6bW5vTBplywD9iVbT1S6KHVplFALYcw2NkapQowCR0PHq4BmI51csQVCFKg=="
     },
     "nav-frontend-skjema": {
@@ -8601,22 +8601,22 @@
     },
     "nav-frontend-skjema-style": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nav-frontend-skjema-style/-/nav-frontend-skjema-style-1.0.5.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-skjema-style/-/nav-frontend-skjema-style-1.0.5.tgz",
       "integrity": "sha512-Wr9rNbi8+91VLRwoSmTG8J6ntf5a4DOSXhKlV+p9F7JZl2uWRF1v5K46zYTRzMk6GZfYJj93lVHVH/k8wEnOIA=="
     },
     "nav-frontend-snakkeboble-style": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/nav-frontend-snakkeboble-style/-/nav-frontend-snakkeboble-style-0.2.6.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-snakkeboble-style/-/nav-frontend-snakkeboble-style-0.2.6.tgz",
       "integrity": "sha512-HeMVM/t6Y8P2FqivyZ4PedlqMj32/U8ugtLDLm98qr3jqnhYTGq104aXjVSLmEAqq5+nCtg5quh3HyKFM5iRMg=="
     },
     "nav-frontend-typografi": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/nav-frontend-typografi/-/nav-frontend-typografi-2.0.5.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-typografi/-/nav-frontend-typografi-2.0.5.tgz",
       "integrity": "sha512-mJR8WVktnGVE8zHGvTCOFV6D9wApXk4IBgVxUjhrycrCxIibV6ZTnKSCkf6Q2l977Oh9pQTRNsUnv79hDtbEgw=="
     },
     "nav-frontend-typografi-style": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/nav-frontend-typografi-style/-/nav-frontend-typografi-style-1.0.9.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-typografi-style/-/nav-frontend-typografi-style-1.0.9.tgz",
       "integrity": "sha512-Do1BB3cyWBKw++N6M7wv3408a9EF1VmRM/BhUqHvA5GalDcC4gVvgpxW+8HjCSefuUOVDJ3vseWjBPlgd12Zug==",
       "requires": {
         "nav-frontend-core": "^4.0.2"
@@ -8673,7 +8673,7 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
@@ -8943,7 +8943,7 @@
     },
     "nyc": {
       "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-10.3.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/nyc/-/nyc-10.3.2.tgz",
       "integrity": "sha1-8n9NkfKp2zbCT1dP9cbv/wIz3kY=",
       "dev": true,
       "requires": {
@@ -10578,7 +10578,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -10588,7 +10588,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -10856,7 +10856,7 @@
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
@@ -11000,7 +11000,7 @@
     },
     "postcss-load-config": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "dev": true,
       "requires": {
@@ -11012,7 +11012,7 @@
     },
     "postcss-load-options": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "dev": true,
       "requires": {
@@ -11022,7 +11022,7 @@
     },
     "postcss-load-plugins": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "dev": true,
       "requires": {
@@ -11032,7 +11032,7 @@
     },
     "postcss-loader": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.5.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/postcss-loader/-/postcss-loader-2.0.5.tgz",
       "integrity": "sha1-wZ0+i4PrGsMW9WIe9MDvWz0bizo=",
       "dev": true,
       "requires": {
@@ -11151,7 +11151,7 @@
     },
     "prop-types": {
       "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
         "fbjs": "^0.8.16",
@@ -12077,7 +12077,7 @@
     },
     "replace-ext": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
@@ -12190,7 +12190,7 @@
     },
     "require-from-string": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/require-from-string/-/require-from-string-1.2.1.tgz",
       "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
       "dev": true
     },
@@ -12272,7 +12272,7 @@
     },
     "rewire": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/rewire/-/rewire-2.5.2.tgz",
       "integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=",
       "dev": true
     },
@@ -12325,7 +12325,7 @@
     },
     "run-sequence": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.5.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/run-sequence/-/run-sequence-1.1.5.tgz",
       "integrity": "sha1-VWvUfrR4dzSeNsnFgnSIl9t75Pc=",
       "dev": true,
       "requires": {
@@ -12502,7 +12502,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -12601,7 +12601,7 @@
       "dependencies": {
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
@@ -12794,7 +12794,7 @@
     },
     "source-list-map": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/source-list-map/-/source-list-map-0.1.8.tgz",
       "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
       "dev": true
     },
@@ -12833,7 +12833,7 @@
     },
     "sparkles": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/sparkles/-/sparkles-1.0.1.tgz",
       "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
       "dev": true
     },
@@ -13571,7 +13571,7 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
@@ -13615,7 +13615,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
@@ -13888,7 +13888,7 @@
     },
     "vinyl": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
@@ -13899,7 +13899,7 @@
     },
     "vinyl-source-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
       "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
       "dev": true,
       "requires": {
@@ -13909,19 +13909,19 @@
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
           "dev": true
         },
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -13933,13 +13933,13 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -13949,7 +13949,7 @@
         },
         "vinyl": {
           "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
@@ -15345,7 +15345,7 @@
     },
     "webpack-sources": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/webpack-sources/-/webpack-sources-0.1.5.tgz",
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
       "dev": true,
       "requires": {

--- a/test/reducers/kontaktinfoTest.js
+++ b/test/reducers/kontaktinfoTest.js
@@ -63,4 +63,121 @@ describe('kontaktinfo', () => {
             });
         });
     });
+
+    describe('henter, med kall som feiler og så går gjennom', () => {
+        it('HENTER_KONTAKTINFO skal fjerne fnr fra hentingFeilet-listen', () => {
+            const state = deepFreeze({
+                henter: [],
+                hentet: [],
+                hentingFeilet: ['fnr'],
+                data: [],
+            });
+
+            const action = actions.henterKontaktinfo('fnr');
+            const nextState = kontaktinfo(state, action);
+
+            expect(nextState).to.deep.equal({
+                henter: ['fnr'],
+                hentet: [],
+                hentingFeilet: [],
+                data: [],
+            });
+        });
+
+        it('HENT_KONTAKTINFO_FEILET Skal fjerne fnr fra henter-lister', () => {
+            const state = deepFreeze({
+                henter: ['fnr'],
+                hentet: [],
+                hentingFeilet: [],
+                data: [],
+            });
+
+            const action = actions.hentKontaktinfoFeilet('fnr');
+            const nextState = kontaktinfo(state, action);
+
+            expect(nextState).to.deep.equal({
+                henter: [],
+                hentet: [],
+                hentingFeilet: ['fnr'],
+                data: [],
+            });
+        });
+
+        it('KONTAKTINFO_HENTET skal fjerne fnr fra henter-listen', () => {
+            const state = deepFreeze({
+                henter: ['fnr1'],
+                hentet: [],
+                hentingFeilet: ['fnr2'],
+                data: [],
+            });
+
+            const action = actions.kontaktinfoHentet({
+                fnr: 'fnr1',
+                tlf: '123',
+                epost: 'test@nav.no',
+            }, 'fnr1',
+            );
+            const nextState = kontaktinfo(state, action);
+
+            expect(nextState).to.deep.equal({
+                henter: [],
+                hentet: ['fnr1'],
+                hentingFeilet: ['fnr2'],
+                data: [{
+                    kontaktinfo: {
+                        fnr: 'fnr1',
+                        tlf: '123',
+                        epost: 'test@nav.no',
+                    },
+                    fnr: 'fnr1',
+                }],
+            });
+        });
+
+        it('KONTAKTINFO_HENTET skal fjerne fnr fra hentingFeilet-listen', () => {
+            const state = deepFreeze({
+                henter: [],
+                hentet: ['fnr1'],
+                hentingFeilet: ['fnr2'],
+                data: [{
+                    kontaktinfo: {
+                        fnr: 'fnr1',
+                        tlf: '123',
+                        epost: 'test@nav.no',
+                    },
+                    fnr: 'fnr1',
+                }],
+            });
+
+            const action = actions.kontaktinfoHentet({
+                fnr: 'fnr2',
+                tlf: '123',
+                epost: 'test@nav.no',
+            }, 'fnr2',
+            );
+            const nextState = kontaktinfo(state, action);
+
+            expect(nextState).to.deep.equal({
+                henter: [],
+                hentet: ['fnr1', 'fnr2'],
+                hentingFeilet: [],
+                data: [{
+                    kontaktinfo: {
+                        fnr: 'fnr1',
+                        tlf: '123',
+                        epost: 'test@nav.no',
+                    },
+                    fnr: 'fnr1',
+                },
+                {
+                    kontaktinfo: {
+                        fnr: 'fnr2',
+                        tlf: '123',
+                        epost: 'test@nav.no',
+                    },
+                    fnr: 'fnr2',
+                }],
+            });
+        });
+    });
 });


### PR DESCRIPTION
Når man endrer state på et fnr (f.eks. går fra henter til hentingFeilet) skal fødselsnummeret legges til i riktig liste i reduceren, og fjernes fra den forrige.
Frem til nå, har det vært feil i filter-metodene, som gjør at et fnr aldri fjernes fra den listen det opprinnelig ble lagt i.

Dette har gjort at når et kall har feilet, har fødselsnummeret blitt liggende i henter-listen, og vi har fått evig spinner.