### PR TITLE
Use stable, predictable and unique key in TiltakUtvidbar

### DIFF
--- a/js/components/oppfolgingsdialog/utfylling/arbeidsoppgaver/ArbeidsoppgaverListe.js
+++ b/js/components/oppfolgingsdialog/utfylling/arbeidsoppgaver/ArbeidsoppgaverListe.js
@@ -14,14 +14,14 @@ const ArbeidsoppgaverListe = (
     return (
         <div className="oppfolgingsdialogtabell">
             {
-                liste.map((element, index) => {
+                liste.map((element) => {
                     return (
                         <ArbeidsoppgaveUtvidbar
-                            key={index}
+                            key={element.arbeidsoppgaveId}
                             element={element}
                             fnr={fnr}
                             sendSlett={sendSlett}
-                            id={index}
+                            id={element.arbeidsoppgaveId}
                             visFeilMelding={visFeilMelding}
                             feilMelding={feilMelding}
                         />);

--- a/js/components/oppfolgingsdialog/utfylling/tiltak/liste/TiltakListe.js
+++ b/js/components/oppfolgingsdialog/utfylling/tiltak/liste/TiltakListe.js
@@ -18,17 +18,17 @@ const TiltakListe = (
     return (
         <div className="oppfolgingsdialogtabell">
             {
-                liste.map((element, index) => {
+                liste.map((element) => {
                     return (
                         <TiltakUtvidbar
-                            key={index}
+                            key={element.tiltakId}
                             element={element}
                             fnr={fnr}
                             sendSlett={sendSlett}
                             sendLagre={sendLagre}
                             sendSlettKommentar={sendSlettKommentar}
                             sendLagreKommentar={sendLagreKommentar}
-                            id={index}
+                            id={element.tiltakId}
                             visFeilMelding={visFeilMelding}
                             feilMelding={feilMelding}
                             rootUrlImg={rootUrlImg}


### PR DESCRIPTION
Array index is not stable, and if used as key in a react component, it
can change when an element is deleted. It's an antipattern:

https://codeburst.io/how-to-not-react-common-anti-patterns-and-gotchas-in-react-40141fe0dcd

and is what caused the deleted elements component, to give its state to the
component in the following element.

Also stop using array index as key in ArbeidsoppgaveUtvidbar.